### PR TITLE
Refactor2library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 obj
 *.suo
+*.user

--- a/wpXml2Jekyll/Program.cs
+++ b/wpXml2Jekyll/Program.cs
@@ -11,11 +11,27 @@ namespace wpXml2Jekyll
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new UIForm());
+            if (args.Length == 0)
+            {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.Run(new UIForm());
+            }
+            else
+            {
+                if (args.Length != 2)
+                {
+                    Console.WriteLine("Usage: wpXml2Jekyll [wordpress export file] [output folder]");
+                    Environment.Exit(1);
+                }
+                var wordpressXmlFile = args[0];
+                var outputFolder = args[1];
+                var application = new UIForm();
+                var posts = application.ReadPosts(wordpressXmlFile, s => { });
+                application.WritePostToMarkdown(posts, outputFolder);
+            }
         }
     }
 }

--- a/wpXml2Jekyll/UIForm.cs
+++ b/wpXml2Jekyll/UIForm.cs
@@ -46,10 +46,10 @@ namespace wpXml2Jekyll
                 return;
             }
 
-            lines = PopulateLines(openFileDialog1.FileName, add2List);
+            lines = ReadPosts(openFileDialog1.FileName, add2List);
         }
 
-        public LinkedList<string> PopulateLines(string fileName, Action<string> reporter)
+        public LinkedList<string> ReadPosts(string fileName, Action<string> reporter)
         {
             using (TextReader tr = new StreamReader(fileName, Encoding.UTF8))
             {
@@ -143,10 +143,10 @@ namespace wpXml2Jekyll
                 return;
             }
 
-            WritePostToMarkdown(lines);
+            WritePostToMarkdown(lines, folderBrowserDialog1.SelectedPath);
         }
 
-        public void WritePostToMarkdown(LinkedList<string> linesToWrite)
+        public void WritePostToMarkdown(LinkedList<string> linesToWrite, string outputFolder)
         {
             LinkedList<Post> posts = new LinkedList<Post>();
 
@@ -161,7 +161,7 @@ namespace wpXml2Jekyll
             {
                 using (
                     TextWriter tw =
-                        new StreamWriter(folderBrowserDialog1.SelectedPath + Path.DirectorySeparatorChar +
+                        new StreamWriter(outputFolder + Path.DirectorySeparatorChar +
                                          p.date.ToString("yyyy-MM-dd-") + p.postURL + ".md"))
                 {
                     tw.WriteLine("---");

--- a/wpXml2Jekyll/UIForm.cs
+++ b/wpXml2Jekyll/UIForm.cs
@@ -16,8 +16,6 @@ namespace wpXml2Jekyll
         LinkedList<String> lines = new LinkedList<string>();
         LinkedList<Post> posts = new LinkedList<Post>();
 
-        bool title = false;
-
         public UIForm()
         {
             InitializeComponent();
@@ -53,34 +51,38 @@ namespace wpXml2Jekyll
                 return;
             }
 
-            lines = PopulateLines(openFileDialog1.FileName);
+            lines = PopulateLines(openFileDialog1.FileName, add2List);
         }
 
-        public LinkedList<string> PopulateLines(string fileName )
+        public LinkedList<string> PopulateLines(string fileName, Action<string> reporter)
         {
             using (TextReader tr = new StreamReader(fileName, Encoding.UTF8))
             {
                 var exportFileContent = tr.ReadToEnd();
 
-                return ParseExportFileContent(exportFileContent);
+                return ParseExportFileContent(exportFileContent, reporter);
             }
         }
 
-        private LinkedList<string> ParseExportFileContent(string exportFileContent)
+
+        private LinkedList<string> ParseExportFileContent(string exportFileContent, Action<string> reporter)
         {
             using (StringReader stringReader = new StringReader(exportFileContent))
             {
                 var parsedLines = new LinkedList<string>();
                 string line;
+                bool title = false;
+
                 while ((line = stringReader.ReadLine()) != null)
                 {
                     if (line.Contains("<title>"))
                     {
+
                         if (title)
                         {
                             line = line.Substring(line.IndexOf('>') + 1, line.LastIndexOf('<') - line.IndexOf('>') - 1);
                             parsedLines.AddLast(line);
-                            add2List(line);
+                            reporter(line);
                         }
                         else
                         {
@@ -96,14 +98,14 @@ namespace wpXml2Jekyll
                         DateTime date = new DateTime(year, month, day);
 
                         parsedLines.AddLast(line.ToString());
-                        add2List(date.ToShortDateString());
+                        reporter(date.ToShortDateString());
                     }
                     else if (line.Contains("<content:encoded>") && line.Contains("</content:encoded>"))
                     {
                         line = line.Substring(28);
                         line = line.Substring(0, line.Length - 21);
                         parsedLines.AddLast(line);
-                        add2List(line);
+                        reporter(line);
                     }
                     else if (line.Contains("<content:encoded>"))
                     {
@@ -118,13 +120,13 @@ namespace wpXml2Jekyll
                         line = line.Substring(28);
                         line = line.Substring(0, line.Length - 21);
                         parsedLines.AddLast(line);
-                        add2List(line);
+                        reporter(line);
                     }
                     else if (line.Contains("<wp:post_name>"))
                     {
                         line = line.Substring(line.IndexOf('>') + 1, line.LastIndexOf('<') - line.IndexOf('>') - 1);
                         parsedLines.AddLast(line);
-                        add2List(line);
+                        reporter(line);
                     }
                 }
                 return parsedLines;

--- a/wpXml2Jekyll/UIForm.cs
+++ b/wpXml2Jekyll/UIForm.cs
@@ -1,20 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using System.IO;
-using System.Xml;
 
 namespace wpXml2Jekyll
 {
     public partial class UIForm : Form
     {
         LinkedList<String> lines = new LinkedList<string>();
-        LinkedList<Post> posts = new LinkedList<Post>();
 
         public UIForm()
         {
@@ -148,27 +143,36 @@ namespace wpXml2Jekyll
                 return;
             }
 
-            posts.Clear();
+            WritePostToMarkdown(lines);
+        }
 
-            for (int i = 0; i < lines.Count; i += 4)
+        public void WritePostToMarkdown(LinkedList<string> linesToWrite)
+        {
+            LinkedList<Post> posts = new LinkedList<Post>();
+
+            for (int i = 0; i < linesToWrite.Count; i += 4)
             {
-                posts.AddLast(new Post(lines.ElementAt(i), lines.ElementAt(i + 2), lines.ElementAt(i + 1), lines.ElementAt(i + 3)));
+                posts.AddLast(new Post(linesToWrite.ElementAt(i), linesToWrite.ElementAt(i + 2), linesToWrite.ElementAt(i + 1),
+                    linesToWrite.ElementAt(i + 3)));
             }
 
-            TextWriter tw;
 
             foreach (Post p in posts)
             {
-                tw = new StreamWriter(folderBrowserDialog1.SelectedPath + "\\" + p.date.ToString("yyyy-MM-dd-") + p.postURL + ".md");
-                tw.WriteLine("---");
-                tw.WriteLine("layout: post");
-                tw.WriteLine("title: " + p.postTitle);
-                tw.WriteLine("date: " + p.date.ToString("yyyy-MM-dd HH:mm"));
-                tw.WriteLine("comments: true");
-                tw.WriteLine("categories: []");
-                tw.WriteLine("---");
-                tw.WriteLine(p.post);
-                tw.Close();
+                using (
+                    TextWriter tw =
+                        new StreamWriter(folderBrowserDialog1.SelectedPath + Path.DirectorySeparatorChar +
+                                         p.date.ToString("yyyy-MM-dd-") + p.postURL + ".md"))
+                {
+                    tw.WriteLine("---");
+                    tw.WriteLine("layout: post");
+                    tw.WriteLine("title: " + p.postTitle);
+                    tw.WriteLine("date: " + p.date.ToString("yyyy-MM-dd HH:mm"));
+                    tw.WriteLine("comments: true");
+                    tw.WriteLine("categories: []");
+                    tw.WriteLine("---");
+                    tw.WriteLine(p.post);
+                }
             }
         }
     }

--- a/wpXml2Jekyll/wpXml2Jekyll.csproj
+++ b/wpXml2Jekyll/wpXml2Jekyll.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{667FCA6E-6534-4EB3-AB18-7A829D7B3D46}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>wpXml2Jekyll</RootNamespace>
     <AssemblyName>wpXml2Jekyll</AssemblyName>
@@ -33,6 +33,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
The application can now be run both as command line and forms application. However this means that the forms version also starts a console window (for now at least).

To use the forms application: just start `wpXml2Jekyll.exe` normally. To start as command line use following syntax:  `wpXml2Jekyll [wordpress export file] [output folder]`
