### PR TITLE
Split posts into folders based on their wp:status.

### DIFF
--- a/wpXml2Jekyll/PostWriter.cs
+++ b/wpXml2Jekyll/PostWriter.cs
@@ -35,6 +35,7 @@ namespace wpXml2Jekyll
 
                         String postStatus = item.SelectSingleNode("wp:status", namespaceManager).InnerText;
                         var folderPath = AppendStatusToOutputFolder(outputFolder, postStatus);
+                        CreateDirectoryIfDoesntExist(folderPath);
 
                         using (
                             TextWriter tw =
@@ -68,16 +69,20 @@ namespace wpXml2Jekyll
             return postCount;
         }
 
+        private static void CreateDirectoryIfDoesntExist(string folderPath)
+        {
+            if (!Directory.Exists(folderPath))
+            {
+                Directory.CreateDirectory(folderPath);
+            }
+        }
+
         private static string AppendStatusToOutputFolder(string outputFolder, string postStatus)
         {
             String folderPath = outputFolder;
             if (!String.IsNullOrWhiteSpace(postStatus))
             {
                 folderPath = outputFolder + Path.DirectorySeparatorChar + postStatus;
-                if (!Directory.Exists(folderPath))
-                {
-                    Directory.CreateDirectory(folderPath);
-                }
             }
             return folderPath;
         }

--- a/wpXml2Jekyll/PostWriter.cs
+++ b/wpXml2Jekyll/PostWriter.cs
@@ -33,9 +33,12 @@ namespace wpXml2Jekyll
 
                         var categories = item.SelectNodes("category", namespaceManager);
 
+                        String postStatus = item.SelectSingleNode("wp:status", namespaceManager).InnerText;
+                        var folderPath = AppendStatusToOutputFolder(outputFolder, postStatus);
+
                         using (
                             TextWriter tw =
-                                new StreamWriter(outputFolder + Path.DirectorySeparatorChar +
+                                new StreamWriter(folderPath + Path.DirectorySeparatorChar +
                                                  p.date.ToString("yyyy-MM-dd-") + p.url + ".md"))
                         {
                             tw.WriteLine("---");
@@ -63,6 +66,20 @@ namespace wpXml2Jekyll
                 }
             }
             return postCount;
+        }
+
+        private static string AppendStatusToOutputFolder(string outputFolder, string postStatus)
+        {
+            String folderPath = outputFolder;
+            if (!String.IsNullOrWhiteSpace(postStatus))
+            {
+                folderPath = outputFolder + Path.DirectorySeparatorChar + postStatus;
+                if (!Directory.Exists(folderPath))
+                {
+                    Directory.CreateDirectory(folderPath);
+                }
+            }
+            return folderPath;
         }
     }
 }


### PR DESCRIPTION
Instead of putting all posts into the specified output folder, this splits them into subfolders based on their status in Wordpress. I only came across "publish", "draft", and "private", though this'll handle anything else as well since it just uses the field value as the subfolder name.
