### PR TITLE
Escape Titles in Markdown Export

### DIFF
--- a/wpXml2Jekyll/PostWriter.cs
+++ b/wpXml2Jekyll/PostWriter.cs
@@ -46,7 +46,7 @@ namespace wpXml2Jekyll
                             tw.WriteLine("---");
                             tw.Write("layout: ");
                             tw.WriteLine(postType);//different layout for pages
-                            tw.WriteLine("title: " + p.title);
+                            tw.WriteLine("title: \"" + p.title + "\"");
                             tw.WriteLine("date: " + p.date.ToString("yyyy-MM-dd HH:mm"));
                             tw.WriteLine("author: " + p.author);
                             tw.WriteLine("comments: true");

--- a/wpXml2Jekyll/PostWriter.cs
+++ b/wpXml2Jekyll/PostWriter.cs
@@ -46,7 +46,7 @@ namespace wpXml2Jekyll
                             tw.WriteLine("---");
                             tw.Write("layout: ");
                             tw.WriteLine(postType);//different layout for pages
-                            tw.WriteLine("title: \"" + p.title + "\"");
+                            tw.WriteLine("title: \"" + p.title.Replace("\"", "&quot;") + "\"");
                             tw.WriteLine("date: " + p.date.ToString("yyyy-MM-dd HH:mm"));
                             tw.WriteLine("author: " + p.author);
                             tw.WriteLine("comments: true");


### PR DESCRIPTION
If you have a title in your blogpost with a colon wpXml2Jekyll will create such an header:

---

   layout: post
   title: Foobar: Test
   ...

---

Jekyll (and I guess all Markdown readers) can't read such a file. Simple trick: Put "" around the title and everything is fine.
